### PR TITLE
Lock ringio with a mutex

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            go test -v ./...
+            go test -race -timeout=5s -v ./...
 
   benchmarks:
     docker:

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -13,7 +13,8 @@ import (
 // bytes as are given for the capacity before it has to be drained by
 // reading from it.
 //
-// It is able to safely read and write in parallel, protected by a Mutex.
+// It is able to safely read and write in parallel, protected by a
+// Mutex.
 type Bounded struct {
 	sync.Mutex
 	r         o.Ring
@@ -77,4 +78,15 @@ func (b *Bounded) Read(p []byte) (n int, err error) {
 		n++
 	}
 	return
+}
+
+func (b *Bounded) reset() {
+	b.r = o.NewRingForSlice(byteSlice(b.buf))
+}
+
+// Reset throws away all data on the ring buffer.
+func (b *Bounded) Reset() {
+	b.Lock()
+	defer b.Unlock()
+	b.reset()
 }

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -66,6 +66,9 @@ func (b *Bounded) Read(p []byte) (n int, err error) {
 
 	var i uint
 	for {
+		if n >= len(p) {
+			return
+		}
 		i, err = b.r.Shift()
 		if err == o.ErrEmpty {
 			return n, nil

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -33,7 +33,7 @@ func (bs byteSlice) Len() int {
 // will fail.
 func New(cap uint, overwrite bool) *Bounded {
 	buf := make([]byte, cap)
-	ring := o.NewRing(cap)
+	ring := o.NewRingForSlice(byteSlice(buf))
 	return &Bounded{r: ring, buf: buf, overwrite: overwrite}
 }
 

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -4,33 +4,41 @@ package ringio
 
 import (
 	"io"
+	"sync"
 
 	"github.com/antifuchs/o"
 )
 
 // Bounded is an io.Reader and io.Writer that allows writing as many
-// bytes as are given for the capacity before it has to be drained.
+// bytes as are given for the capacity before it has to be drained by
+// reading from it.
+//
+// It is able to safely read and write in parallel, protected by a Mutex.
 type Bounded struct {
-	o.Ring
+	r         o.Ring
 	buf       []byte
 	overwrite bool
 }
 
+// New returns a bounded ring buffer of the given capacity. If
+// overwrite is true, a full ring buffer will discard unread bytes and
+// overwrite them upon writes. Otherwise, writes on a full ring buffer
+// will fail.
 func New(cap uint, overwrite bool) *Bounded {
 	buf := make([]byte, cap)
-	return &Bounded{Ring: o.NewRing(cap), buf: buf, overwrite: overwrite}
+	return &Bounded{r: o.NewRing(cap), buf: buf, overwrite: overwrite}
 }
 
 func (b *Bounded) Write(p []byte) (n int, err error) {
 	var i uint
 	for n, c := range p {
 		if b.overwrite {
-			i, err = b.Ring.Push()
+			i = o.ForcePush(b.r)
+		} else {
+			i, err = b.r.Push()
 			if err == o.ErrFull {
 				return n, io.ErrShortWrite
 			}
-		} else {
-			i = o.ForcePush(b.Ring)
 		}
 		b.buf[i] = c
 	}
@@ -38,12 +46,12 @@ func (b *Bounded) Write(p []byte) (n int, err error) {
 }
 
 func (b *Bounded) Read(p []byte) (n int, err error) {
-	if b.Ring.Empty() {
+	if b.r.Empty() {
 		return 0, io.EOF
 	}
 	var i uint
 	for {
-		i, err = b.Ring.Shift()
+		i, err = b.r.Shift()
 		if err == o.ErrEmpty {
 			return n, nil
 		}

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -45,3 +45,44 @@ func TestReadOverwrites(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("he buffer"), buf)
 }
+
+func TestParallel(t *testing.T) {
+	t.Parallel()
+
+	b := New(27, false)
+	quit := make(chan struct{})
+	write := func(toWrite []byte) {
+		for {
+			select {
+			case <-quit:
+				return
+			default:
+				b.Write(toWrite)
+			}
+		}
+	}
+	go write([]byte("abc"))
+	go write([]byte("abc"))
+
+	for i := 0; i < 1000; i++ {
+		didRead := make([]byte, 6)
+		n, err := b.Read(didRead)
+		if err == o.ErrEmpty {
+			continue
+		}
+		if err == io.EOF {
+			break
+		}
+		require.NoError(t, err)
+		switch n {
+		case 3:
+			assert.Equal(t, []byte("abc"), didRead[0:3])
+		case 6:
+			assert.Equal(t, []byte("abcabc"), didRead)
+		default:
+			t.Fatalf("Read %d bytes, expected 3 or 6", n)
+		}
+	}
+
+	close(quit)
+}

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -86,3 +86,22 @@ func TestParallel(t *testing.T) {
 
 	close(quit)
 }
+
+func TestReset(t *testing.T) {
+	t.Parallel()
+
+	b := New(8, true)
+	n, err := b.Write([]byte("hi this is a test"))
+	require.NoError(t, err)
+	assert.Equal(t, 17, n)
+
+	read := make([]byte, 4)
+	n, err = b.Read(read)
+	require.NoError(t, err)
+	assert.Equal(t, 4, n)
+	b.Reset()
+
+	n, err = b.Read(read)
+	assert.Equal(t, io.EOF, err)
+	assert.Equal(t, 0, n)
+}

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -4,11 +4,15 @@ import (
 	"io"
 	"testing"
 
+	"github.com/antifuchs/o"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadBoundedWrites(t *testing.T) {
-	b := New(9, true)
+	t.Parallel()
+
+	b := New(9, false)
 	n, err := b.Write([]byte("hi"))
 	assert.NoError(t, err)
 	assert.Equal(t, 2, n)
@@ -25,7 +29,9 @@ func TestReadBoundedWrites(t *testing.T) {
 }
 
 func TestReadOverwrites(t *testing.T) {
-	b := New(9, false)
+	t.Parallel()
+
+	b := New(9, true)
 	n, err := b.Write([]byte("hi"))
 	assert.NoError(t, err)
 	assert.Equal(t, 2, n)


### PR DESCRIPTION
This PR adds a mutex around the Read & Write operations, which allows users to read from/write to it in multiple goroutines.