### PR TITLE
Property tests with gopter

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       - run:
           name: Run tests
           command: |
-            go test -race -timeout=5s -v ./...
+            go test -race -timeout=15s -v ./...
 
   benchmarks:
     docker:

--- a/ranges.go
+++ b/ranges.go
@@ -74,7 +74,7 @@ func Reserve(ring Ring, count uint) (first, second Range, err error) {
 	end1 := ring.Mask(first.Start + added)
 
 	first.End = end1
-	if end1 <= first.Start {
+	if end1 <= first.Start && added > 0 {
 		second.End = end1
 		first.End = ring.capacity()
 	}

--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -1,0 +1,123 @@
+package o_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/antifuchs/o"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+)
+
+func TestPropMatchingRanges(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+	properties.Property("Ranges in scanners match", prop.ForAll(
+		func(cap, overage uint) string {
+			ring := o.NewRing(cap)
+			insert := cap + overage
+			for i := uint(0); i < insert; i++ {
+				o.ForcePush(ring)
+			}
+			if ring.Size() != cap {
+				return "Size does not match cap"
+			}
+
+			fifo := make([]uint, 0, cap)
+			lifo := make([]uint, 0, cap)
+
+			s := o.ScanLIFO(ring)
+			for i := 0; s.Next(); i++ {
+				lifo = append(lifo, s.Value())
+			}
+
+			s = o.ScanFIFO(ring)
+			for i := 0; s.Next(); i++ {
+				fifo = append(fifo, s.Value())
+			}
+			if len(lifo) != len(fifo) {
+				return "Length mismatch between lifo&fifo order"
+			}
+			last := lifo[0]
+			for nth, _ := range lifo {
+				if lifo[nth] != fifo[len(fifo)-1-nth] {
+					return fmt.Sprintf("fifo / lifo mismatch:\n%#v\n%#v", lifo, fifo)
+				}
+				if nth > 0 && ring.Mask(last+1) != lifo[nth] {
+					return fmt.Sprintf("indexes not continuous: %#v", lifo)
+				}
+				last = lifo[nth]
+			}
+			return ""
+		},
+		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(1, 100).WithLabel("overflow"),
+	))
+	properties.TestingRun(t)
+}
+
+func TestPropReserve(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 10000
+	properties := gopter.NewProperties(params)
+	properties.Property("Ranges in scanners match", prop.ForAll(
+		func(cap, fill, read, reserve uint) string {
+			ring := o.NewRing(cap)
+			var startIdx uint
+			for i := uint(0); i < fill; i++ {
+				startIdx = ring.Mask(o.ForcePush(ring) + 1)
+			}
+			for i := uint(0); i < read; i++ {
+				ring.Shift()
+			}
+			startSize := ring.Size()
+			overflows := startSize+reserve > cap
+
+			first, second, err := o.Reserve(ring, reserve)
+			reservedAny := !first.Empty() || !second.Empty()
+			if overflows && err == nil {
+				return "expected error"
+			}
+			if !overflows && err != nil {
+				return "unexpected error"
+			}
+
+			if !overflows && first.Length()+second.Length() != reserve {
+				return fmt.Sprintf("did not reserve %d elements:\n%#v %#v",
+					reserve, first, second)
+			}
+			if overflows && first.Length()+second.Length() != cap-startSize {
+				return fmt.Sprintf("overflowing, did not reserve %d elements:\n%#v %#v",
+					reserve, first, second)
+			}
+			if reservedAny && startIdx != first.Start {
+				return fmt.Sprintf("expected reservation to start at %d, but %#v",
+					startIdx, first)
+			}
+			if !second.Empty() && first.End != cap {
+				return fmt.Sprintf("bad end bound on first range: %d expected, but %#v",
+					cap, first)
+			}
+			if !second.Empty() && second.Start != 0 {
+				return fmt.Sprintf("bad start bound on second range: 0 expected, but %#v",
+					second)
+			}
+			if !second.Empty() && !overflows && second.End != reserve-first.Length() {
+				return fmt.Sprintf("bad end bound on second range: %d expected, but %#v %#v",
+					reserve-first.Length(), first, second)
+			}
+			if !second.Empty() && overflows && second.End != cap-startSize-first.Length() {
+				return fmt.Sprintf("bad end bound on overflowing second range: %d expected, but %#v %#v",
+					cap-startSize-first.Length(), first, second)
+			}
+			return ""
+		},
+		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(0, 100).WithLabel("elements to fill in"),
+		gen.UIntRange(0, 100).WithLabel("elements to read"),
+		gen.UIntRange(0, 100).WithLabel("elements to reserve"),
+	))
+	properties.TestingRun(t)
+}

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -1,12 +1,10 @@
 package o_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/antifuchs/o"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestLIFO(t *testing.T) {
@@ -67,51 +65,6 @@ func TestFIFO(t *testing.T) {
 				results = append(results, s.Value())
 			}
 			assert.Equal(t, test.expected, results)
-		})
-	}
-}
-
-func TestMatching(t *testing.T) {
-	var toinsert = 263 // prime & greater than the max. capacity
-	const min uint = 1
-	const max uint = 256
-	for n := min; n <= max; n++ {
-		test := n
-		t.Run(fmt.Sprintf("%03d", test), func(t *testing.T) {
-			t.Parallel()
-			ra := o.NewRing(test)
-			for i := 0; i < toinsert; i++ {
-				o.ForcePush(ra)
-			}
-			assert.Equal(t, ra.Size(), test)
-
-			fifo := make([]uint, 0, test)
-			lifo := make([]uint, 0, test)
-
-			s := o.ScanLIFO(ra)
-			for i := 0; s.Next(); i++ {
-				lifo = append(lifo, s.Value())
-			}
-
-			s = o.ScanFIFO(ra)
-			for i := 0; s.Next(); i++ {
-				fifo = append(fifo, s.Value())
-			}
-			assert.Equal(t, len(lifo), len(fifo))
-			assert.Equal(t, fifo[0], lifo[len(lifo)-1])
-			assert.Equal(t, lifo[0], fifo[len(fifo)-1])
-			// check contiguity:
-			last := lifo[0]
-			for nth, i := range lifo[1:] {
-				require.Equal(t, ra.Mask(last+1), i, "at %d", nth)
-				last = i
-			}
-
-			last = fifo[0]
-			for nth, i := range fifo[1:] {
-				require.Equal(t, ra.Mask(last+test-1), i, "at %d", nth)
-				last = i
-			}
 		})
 	}
 }

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -170,22 +170,6 @@ func TestReserve(t *testing.T) {
 			first: o.Range{0, 0}, second: o.Range{0, 0},
 		},
 		{
-			name:  "basic5/fill:4/13",
-			cap:   5,
-			fill:  4,
-			add:   13,
-			first: o.Range{4, 5}, second: o.Range{0, 0},
-			err: o.ErrFull,
-		},
-		{
-			name:  "basic4/fill:3/13",
-			cap:   4,
-			fill:  3,
-			add:   13,
-			first: o.Range{3, 4}, second: o.Range{0, 0},
-			err: o.ErrFull,
-		},
-		{
 			name:  "centered",
 			cap:   5,
 			fill:  4,

--- a/ring.go
+++ b/ring.go
@@ -67,7 +67,8 @@ type Ring interface {
 }
 
 // ForcePush forces a new element onto the ring, discarding the oldest
-// element if the ring is full.
+// element if the ring is full. It returns the index of the inserted
+// element.
 func ForcePush(r Ring) uint {
 	if r.Full() {
 		_, _ = r.Shift()

--- a/ring_properties_test.go
+++ b/ring_properties_test.go
@@ -1,7 +1,6 @@
 package o_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/antifuchs/o"
@@ -31,53 +30,5 @@ func TestPropShiftPushes(t *testing.T) {
 		gen.UIntRange(1, 257*90).WithLabel("number of entries made"),
 	),
 	)
-	properties.TestingRun(t)
-}
-
-func TestPropMatchingRanges(t *testing.T) {
-	params := gopter.DefaultTestParameters()
-	params.MinSuccessfulTests = 1000
-	properties := gopter.NewProperties(params)
-	properties.Property("Ranges in scanners match", prop.ForAll(
-		func(cap, overage uint) string {
-			ring := o.NewRing(cap)
-			insert := cap + overage
-			for i := uint(0); i < insert; i++ {
-				o.ForcePush(ring)
-			}
-			if ring.Size() != cap {
-				return "Size does not match cap"
-			}
-
-			fifo := make([]uint, 0, cap)
-			lifo := make([]uint, 0, cap)
-
-			s := o.ScanLIFO(ring)
-			for i := 0; s.Next(); i++ {
-				lifo = append(lifo, s.Value())
-			}
-
-			s = o.ScanFIFO(ring)
-			for i := 0; s.Next(); i++ {
-				fifo = append(fifo, s.Value())
-			}
-			if len(lifo) != len(fifo) {
-				return "Length mismatch between lifo&fifo order"
-			}
-			last := lifo[0]
-			for nth, _ := range lifo {
-				if lifo[nth] != fifo[len(fifo)-1-nth] {
-					return fmt.Sprintf("fifo / lifo mismatch:\n%#v\n%#v", lifo, fifo)
-				}
-				if nth > 0 && ring.Mask(last+1) != lifo[nth] {
-					return fmt.Sprintf("indexes not continuous: %#v", lifo)
-				}
-				last = lifo[nth]
-			}
-			return ""
-		},
-		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
-		gen.UIntRange(1, 100).WithLabel("ring size"),
-	))
 	properties.TestingRun(t)
 }

--- a/ring_properties_test.go
+++ b/ring_properties_test.go
@@ -1,0 +1,34 @@
+package o_test
+
+import (
+	"testing"
+
+	"github.com/antifuchs/o"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+)
+
+func TestPropShiftPushes(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+	properties.Property("Read own writes", prop.ForAll(
+		func(ringSize, entries uint) bool {
+			ring := o.NewRing(ringSize)
+			for i := uint(0); i < entries; i++ {
+				pushed, _ := ring.Push()
+				shifted, _ := ring.Shift()
+
+				if pushed != shifted {
+					return false
+				}
+			}
+			return true
+		},
+		gen.UInt().SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(1, 257*90).WithLabel("number of entries made"),
+	),
+	)
+	properties.TestingRun(t)
+}

--- a/ring_properties_test.go
+++ b/ring_properties_test.go
@@ -1,6 +1,7 @@
 package o_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/antifuchs/o"
@@ -30,5 +31,53 @@ func TestPropShiftPushes(t *testing.T) {
 		gen.UIntRange(1, 257*90).WithLabel("number of entries made"),
 	),
 	)
+	properties.TestingRun(t)
+}
+
+func TestPropMatchingRanges(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+	properties.Property("Ranges in scanners match", prop.ForAll(
+		func(cap, overage uint) string {
+			ring := o.NewRing(cap)
+			insert := cap + overage
+			for i := uint(0); i < insert; i++ {
+				o.ForcePush(ring)
+			}
+			if ring.Size() != cap {
+				return "Size does not match cap"
+			}
+
+			fifo := make([]uint, 0, cap)
+			lifo := make([]uint, 0, cap)
+
+			s := o.ScanLIFO(ring)
+			for i := 0; s.Next(); i++ {
+				lifo = append(lifo, s.Value())
+			}
+
+			s = o.ScanFIFO(ring)
+			for i := 0; s.Next(); i++ {
+				fifo = append(fifo, s.Value())
+			}
+			if len(lifo) != len(fifo) {
+				return "Length mismatch between lifo&fifo order"
+			}
+			last := lifo[0]
+			for nth, _ := range lifo {
+				if lifo[nth] != fifo[len(fifo)-1-nth] {
+					return fmt.Sprintf("fifo / lifo mismatch:\n%#v\n%#v", lifo, fifo)
+				}
+				if nth > 0 && ring.Mask(last+1) != lifo[nth] {
+					return fmt.Sprintf("indexes not continuous: %#v", lifo)
+				}
+				last = lifo[nth]
+			}
+			return ""
+		},
+		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(1, 100).WithLabel("ring size"),
+	))
 	properties.TestingRun(t)
 }

--- a/ringio/properties_test.go
+++ b/ringio/properties_test.go
@@ -1,0 +1,120 @@
+package ringio_test
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/antifuchs/o/ringio"
+	"github.com/leanovate/gopter"
+	"github.com/leanovate/gopter/gen"
+	"github.com/leanovate/gopter/prop"
+)
+
+func TestPropReadWritesOverwrite(t *testing.T) {
+	t.Parallel()
+	params := gopter.DefaultTestParameters()
+	params.MinSize = 1
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+	properties.Property("read a written slice in an overwriting ring buffer", prop.ForAll(
+		func(cap uint, str string) *gopter.PropResult {
+			input := []byte(str)
+			b := ringio.New(cap, true)
+			n, err := b.Write(input)
+			if err != nil {
+				res := gopter.NewPropResult(false, "writing")
+				res.Error = err
+				return res
+			}
+			if n != len(input) {
+				return gopter.NewPropResult(false,
+					fmt.Sprintf("wrong written length %d!=%d", n, len(input)))
+			}
+
+			output := make([]byte, n)
+			n, err = b.Read(output)
+			if err != nil {
+				res := gopter.NewPropResult(false, "reading")
+				res.Error = err
+				return res
+			}
+			if cap >= uint(len(input)) {
+				if n != len(input) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("wrong read length %d!=%d", n, len(input)))
+				}
+				if !reflect.DeepEqual(output, input) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("buffers are not equal: %#v %#v", input, output))
+				}
+			} else {
+				if uint(n) != cap {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("wrong read length %d!=%d", n, cap))
+				}
+				writtenInput := input[len(input)-n:]
+				if !reflect.DeepEqual(output[0:n], writtenInput) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("buffers are not equal (%d written): %#v %#v", n, output, writtenInput))
+				}
+			}
+
+			return gopter.NewPropResult(true, "")
+		},
+		gen.UIntRange(1, 1024).WithLabel("buffer size"),
+		gen.AnyString().SuchThat(func(x string) bool { return len(x) > 0 }).WithLabel("text to write"),
+	),
+	)
+	properties.TestingRun(t)
+}
+
+func TestPropReadWritesBounded(t *testing.T) {
+	t.Parallel()
+	params := gopter.DefaultTestParameters()
+	params.MinSize = 1
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+	properties.Property("read a written slice in a ring buffer that stops at the boundary", prop.ForAll(
+		func(cap uint, str string) *gopter.PropResult {
+			input := []byte(str)
+			b := ringio.New(cap, false)
+			n, err := b.Write(input)
+
+			output := make([]byte, len(input))
+			n, err = b.Read(output)
+			if err != nil {
+				res := gopter.NewPropResult(false, "reading")
+				res.Error = err
+				return res
+			}
+			if cap >= uint(len(input)) {
+				if n != len(input) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("wrong read length %d!=%d", n, len(input)))
+				}
+				if !reflect.DeepEqual(output, input) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("buffers are not equal: %#v %#v", input, output))
+				}
+			} else {
+				if uint(n) != cap {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("wrong read length %d!=%d", n, cap))
+				}
+
+				writtenInput := input[0:n]
+				if !reflect.DeepEqual(output[0:n], writtenInput) {
+					return gopter.NewPropResult(false,
+						fmt.Sprintf("buffers are not equal: %#v %#v", output, writtenInput))
+				}
+			}
+
+			return gopter.NewPropResult(true, "")
+		},
+		gen.UIntRange(1, 1024).WithLabel("buffer size"),
+		gen.AnyString().WithLabel("text to write"),
+	),
+	)
+	properties.TestingRun(t)
+}


### PR DESCRIPTION
This PR adds property tests for stuff that I had already been testing (hardcodedly), but with more scenarios and slightly more robustly.

It also fixes a bug in Reserve, which made the multi-threaded ringio test fail.