### PR TITLE
Improve the Ring interface in a bunch of ways

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,6 +41,9 @@ jobs:
             for d in $(go list ./... | grep -v vendor); do
                 go test -race -coverprofile=/tmp/coverage/$(echo "$d" | tr / _) -timeout=60s -coverpkg="$srcpkg" -v $d
             done
+      - run:
+          name: "Merge coverage"
+          command: |
             gocovmerge /tmp/coverage/* > /tmp/coverage.txt
             go tool cover -html=/tmp/coverage.txt -o /tmp/artifacts/coverage.html
       - store_artifacts:
@@ -64,10 +67,19 @@ jobs:
           name: deps
           command: |
             go get -v -t -d ./...
+            go get github.com/cespare/prettybench
       - run:
           name: Run benchmarks
           command: |
-            go test -run '^$' -bench . -v ./...
+            go test -run '^$' -bench . -v ./... | tee /tmp/benchmarks.txt
+      - run:
+          name: prettybench
+          command: |
+            mkdir -p /tmp/artifacts
+            prettybench < /tmp/benchmarks.txt | tee /tmp/artifacts/benchmarks.txt
+      - store_artifacts:
+          path: /tmp/artifacts
+          destination: /
 
   ci_success:
     docker:

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,11 @@
+---
+comment:
+  require_change: yes
+  behavior: once
+
+coverage:
+  status:
+    project:
+      default:
+        target: "100%"
+    patch: off

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ find an example in the `ringio` package implemented here. These
 functions return errors if you push onto a full ring, or if you shift
 from an empty ring.
 
-You can also use `o.ForcePush` to insert a new element regardless of
-whether the ring is full, overwriting the element that's there.
+You can also use `Ring.ForcePush` to insert a new element regardless
+of whether the ring is full, overwriting the element that's there.
 
 And then, if you do not want to shift out elements to read them, you
 can use `o.ScanFIFO` and `o.ScanLIFO` to get an iterator over the

--- a/basic_ring.go
+++ b/basic_ring.go
@@ -72,4 +72,4 @@ func (r *basicRing) Size() uint {
 	return r.length
 }
 
-var _ Ring = &basicRing{}
+var _ ringBackend = &basicRing{}

--- a/basic_ring.go
+++ b/basic_ring.go
@@ -30,14 +30,14 @@ func (r *basicRing) reset() {
 	r.length = 0
 }
 
-func (r *basicRing) add(n uint) (uint, error) {
-	available := r.cap - r.length
+func (r *basicRing) pushN(n uint) (uint, uint, error) {
+	start := r.length
 	if n > r.cap-r.length {
-		r.length = r.cap
-		return available, ErrFull
+		idx := r.Mask(r.read + start)
+		return idx, idx, ErrFull
 	}
 	r.length += n
-	return n, nil
+	return r.Mask(r.read + start), r.Mask(r.read + r.length), nil
 }
 
 func (r *basicRing) Full() bool {

--- a/basic_ring.go
+++ b/basic_ring.go
@@ -40,22 +40,23 @@ func (r *basicRing) pushN(n uint) (uint, uint, error) {
 	return r.mask(r.read + start), r.mask(r.read + r.length), nil
 }
 
+func (r *basicRing) shiftN(n uint) (uint, uint, error) {
+	start := r.read
+	if n > r.size() {
+		return start, start, ErrEmpty
+	}
+	r.length -= n
+	//i := r.read
+	r.read = r.mask(r.read + n)
+	return start, r.read, nil
+}
+
 func (r *basicRing) full() bool {
 	return r.cap == r.length
 }
 
 func (r *basicRing) empty() bool {
 	return r.length == 0
-}
-
-func (r *basicRing) shift() (uint, error) {
-	if r.empty() {
-		return 0, ErrEmpty
-	}
-	r.length--
-	i := r.read
-	r.read = r.mask(r.read + 1)
-	return i, nil
 }
 
 func (r *basicRing) size() uint {

--- a/basic_ring.go
+++ b/basic_ring.go
@@ -10,7 +10,7 @@ type basicRing struct {
 	cap, read, length uint
 }
 
-func (r *basicRing) Mask(val uint) uint {
+func (r *basicRing) mask(val uint) uint {
 	return val % r.cap
 }
 
@@ -19,7 +19,7 @@ func (r *basicRing) start() uint {
 }
 
 func (r *basicRing) end() uint {
-	return r.Mask(r.read + r.length)
+	return r.mask(r.read + r.length)
 }
 
 func (r *basicRing) capacity() uint {
@@ -33,42 +33,32 @@ func (r *basicRing) reset() {
 func (r *basicRing) pushN(n uint) (uint, uint, error) {
 	start := r.length
 	if n > r.cap-r.length {
-		idx := r.Mask(r.read + start)
+		idx := r.mask(r.read + start)
 		return idx, idx, ErrFull
 	}
 	r.length += n
-	return r.Mask(r.read + start), r.Mask(r.read + r.length), nil
+	return r.mask(r.read + start), r.mask(r.read + r.length), nil
 }
 
-func (r *basicRing) Full() bool {
+func (r *basicRing) full() bool {
 	return r.cap == r.length
 }
 
-func (r *basicRing) Empty() bool {
+func (r *basicRing) empty() bool {
 	return r.length == 0
 }
 
-func (r *basicRing) Push() (uint, error) {
-	if r.Full() {
-		return 0, ErrFull
-	}
-	l := r.length
-	r.length++
-
-	return r.Mask(r.read + l), nil
-}
-
-func (r *basicRing) Shift() (uint, error) {
-	if r.Empty() {
+func (r *basicRing) shift() (uint, error) {
+	if r.empty() {
 		return 0, ErrEmpty
 	}
 	r.length--
 	i := r.read
-	r.read = r.Mask(r.read + 1)
+	r.read = r.mask(r.read + 1)
 	return i, nil
 }
 
-func (r *basicRing) Size() uint {
+func (r *basicRing) size() uint {
 	return r.length
 }
 

--- a/bors.toml
+++ b/bors.toml
@@ -3,6 +3,7 @@
 
 status = [
   "ci/circleci: ci_success",
+  "codecov/project",
 ]
 timeout_sec = 300
 delete_merged_branches = true

--- a/doc.go
+++ b/doc.go
@@ -22,19 +22,54 @@
 // Non-destructive operations on Rings
 //
 // If your code needs to only inspect the contents of the ring instead
-// of shifting them out, you can use a stateful iterator in either
-// LIFO or FIFO direction available to do this conveniently:
+// of shifting them out, you can use the Inspect method (which returns
+// ranges, see the next section) or a stateful iterator in either LIFO
+// or FIFO direction available to do this conveniently:
 //
 //     o.ScanLIFO(ring) and
 //     o.ScanFIFO(ring)
 //
 // See Scanner for defails and usage examples.
 //
+// Ranges across a Ring
+//
+// A Ring assumes that all indexes between the first occupied index
+// (the "read" end) and the last occupied index (the "write" end) are
+// continuously occupied. Since rings wrap around to zero, that
+// doesn't mean however, that each continuous index is greater than
+// the index before it
+//
+// To make it easier to deal with these index ranges, every operation
+// that deals with ranges (e.g. Inspect, Consume, PushN) will return
+// two Range objects, by convention named first and second.
+//
+// These ranges cover the two parts of the buffer. Assume a ring
+// buffer like this, x marking occupied elements and _ marking
+// unoccupied ones:
+//
+//      0   1   2   3   4   5   6   7 (Capacity)
+//    +---+---+---+---+---+---+---+
+//    | x | _ | _ | x | x | x | x |
+//    +---+---+---+---+---+---+---+
+//          ^       ^ Read end points here
+//          |
+//          +- Write end points here
+//
+// The way o.Ranges represents a range between the Read and the Write
+// end is:
+//
+//     first  = o.Range{Start: 3, End: 7}
+//     second = o.Range{Start: 0, End: 1}
+//
+// Note that the End index of a range is the first index greater than
+// the one that's occupied. This allows using these Range ends as
+// points in a slice expression without modification.
+//
 // Thread Safety
 //
 // None of the data structures provided here are safe from data
 // races. To use them in thread-safe ring buffer implementations,
-// users must protect both the accounting operations and your backing
+// users must protect both the accounting operations and backing
 // buffer writes with a Mutex.
 //
 // Credit

--- a/fifo_iterator_example_test.go
+++ b/fifo_iterator_example_test.go
@@ -10,7 +10,7 @@ func ExampleScanFIFO() {
 	ring := o.NewRing(17)
 	// Put stuff in the ring:
 	for i := 0; i < 19; i++ {
-		o.ForcePush(ring)
+		ring.ForcePush()
 	}
 
 	// Now find all the indexes in last-in/first-out order:

--- a/lifo_iterator_example_test.go
+++ b/lifo_iterator_example_test.go
@@ -10,7 +10,7 @@ func ExampleScanLIFO() {
 	ring := o.NewRing(17)
 	// Put stuff in the ring:
 	for i := 0; i < 19; i++ {
-		o.ForcePush(ring)
+		ring.ForcePush()
 	}
 
 	// Now find all the indexes in last-in/first-out order:

--- a/mask_ring.go
+++ b/mask_ring.go
@@ -4,12 +4,12 @@ type maskRing struct {
 	cap, read, write uint
 }
 
-func (r *maskRing) Mask(val uint) uint {
+func (r *maskRing) mask(val uint) uint {
 	return val & (r.cap - 1)
 }
 
 func (r *maskRing) start() uint {
-	return r.Mask(r.read)
+	return r.mask(r.read)
 }
 
 func (r *maskRing) reset() {
@@ -21,46 +21,37 @@ func (r *maskRing) capacity() uint {
 }
 
 func (r *maskRing) end() uint {
-	return r.Mask(r.write)
+	return r.mask(r.write)
 }
 
 func (r *maskRing) pushN(n uint) (uint, uint, error) {
 	start := r.write
-	if n > r.cap-r.Size() {
-		return start, start, ErrFull
+	if n > r.cap-r.size() {
+		i := r.mask(start)
+		return i, i, ErrFull
 	}
 	r.write += n
-	return start, r.Mask(r.write), nil
+	return r.mask(start), r.mask(r.write), nil
 }
 
-func (r *maskRing) Full() bool {
-	return r.Size() == r.cap
+func (r *maskRing) full() bool {
+	return r.size() == r.cap
 }
 
-func (r *maskRing) Empty() bool {
+func (r *maskRing) empty() bool {
 	return r.read == r.write
 }
 
-func (r *maskRing) Push() (uint, error) {
-	if r.Full() {
-		return 0, ErrFull
-	}
-	i := r.write
-	r.write++
-
-	return r.Mask(i), nil
-}
-
-func (r *maskRing) Shift() (uint, error) {
-	if r.Empty() {
+func (r *maskRing) shift() (uint, error) {
+	if r.empty() {
 		return 0, ErrEmpty
 	}
 	i := r.read
 	r.read++
-	return r.Mask(i), nil
+	return r.mask(i), nil
 }
 
-func (r *maskRing) Size() uint {
+func (r *maskRing) size() uint {
 	return r.write - r.read
 }
 

--- a/mask_ring.go
+++ b/mask_ring.go
@@ -34,21 +34,21 @@ func (r *maskRing) pushN(n uint) (uint, uint, error) {
 	return r.mask(start), r.mask(r.write), nil
 }
 
+func (r *maskRing) shiftN(n uint) (uint, uint, error) {
+	start := r.mask(r.read)
+	if n > r.size() {
+		return start, start, ErrEmpty
+	}
+	r.read += n
+	return start, r.mask(r.read), nil
+}
+
 func (r *maskRing) full() bool {
 	return r.size() == r.cap
 }
 
 func (r *maskRing) empty() bool {
 	return r.read == r.write
-}
-
-func (r *maskRing) shift() (uint, error) {
-	if r.empty() {
-		return 0, ErrEmpty
-	}
-	i := r.read
-	r.read++
-	return r.mask(i), nil
 }
 
 func (r *maskRing) size() uint {

--- a/mask_ring.go
+++ b/mask_ring.go
@@ -65,4 +65,4 @@ func (r *maskRing) Size() uint {
 	return r.write - r.read
 }
 
-var _ Ring = &maskRing{}
+var _ ringBackend = &maskRing{}

--- a/mask_ring.go
+++ b/mask_ring.go
@@ -24,14 +24,13 @@ func (r *maskRing) end() uint {
 	return r.Mask(r.write)
 }
 
-func (r *maskRing) add(n uint) (uint, error) {
-	space := r.cap - r.Size()
-	if n > space {
-		r.write += space
-		return space, ErrFull
+func (r *maskRing) pushN(n uint) (uint, uint, error) {
+	start := r.write
+	if n > r.cap-r.Size() {
+		return start, start, ErrFull
 	}
 	r.write += n
-	return n, nil
+	return start, r.Mask(r.write), nil
 }
 
 func (r *maskRing) Full() bool {

--- a/ranges.go
+++ b/ranges.go
@@ -32,17 +32,17 @@ func (r Range) Length() uint {
 // accurate picture of the occupied elements. The second range may be
 // empty (Start & Length = 0) if there is nothing occupied on the left
 // part of the buffer.
-func Inspect(ring Ring) (first Range, second Range) {
-	if ring.Empty() {
+func (r Ring) Inspect() (first Range, second Range) {
+	if r.Empty() {
 		return
 	}
-	first.Start = ring.start()
-	end1 := ring.end()
+	first.Start = r.start()
+	end1 := r.end()
 
 	first.End = end1 + 1
 	if end1 <= first.Start {
 		second.End = end1
-		first.End = ring.capacity()
+		first.End = r.capacity()
 	}
 	return
 }
@@ -54,7 +54,7 @@ func Inspect(ring Ring) (first Range, second Range) {
 // See also Inspect.
 func Consume(ring Ring) (first Range, second Range) {
 	defer ring.reset()
-	return Inspect(ring)
+	return ring.Inspect()
 }
 
 // Reserve bulk-pushes count indexes onto the Ring and returns ranges
@@ -93,14 +93,14 @@ type Scanner struct {
 // ScanLIFO returns a Scanner for the given Ring that iterates over
 // the occupied indexes in LIFO (oldest to newest) direction.
 func ScanLIFO(ring Ring) *Scanner {
-	first, second := Inspect(ring)
+	first, second := ring.Inspect()
 	return &Scanner{first.Start, []Range{first, second}, false}
 }
 
 // ScanFIFO returns a Scanner for the given Ring that iterates over
 // the occupied indexes in FIFO (newest to oldest) direction.
 func ScanFIFO(ring Ring) *Scanner {
-	first, second := Inspect(ring)
+	first, second := ring.Inspect()
 	return &Scanner{second.End, []Range{second, first}, true}
 }
 

--- a/ranges.go
+++ b/ranges.go
@@ -52,9 +52,9 @@ func (r Ring) Inspect() (first Range, second Range) {
 // were occupied in the ring prior to resetting.
 //
 // See also Inspect.
-func Consume(ring Ring) (first Range, second Range) {
-	defer ring.reset()
-	return ring.Inspect()
+func (r Ring) Consume() (first Range, second Range) {
+	defer r.reset()
+	return r.Inspect()
 }
 
 // Reserve bulk-pushes count indexes onto the Ring and returns ranges

--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -75,7 +75,7 @@ func TestPropReserve(t *testing.T) {
 			startSize := ring.Size()
 			overflows := startSize+reserve > cap
 
-			first, second, err := o.Reserve(ring, reserve)
+			first, second, err := ring.PushN(reserve)
 			reservedAny := !first.Empty() || !second.Empty()
 			if overflows && err == nil {
 				return "expected error"

--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/leanovate/gopter/prop"
 )
 
-func TestPropMatchingRanges(t *testing.T) {
+func TestPropFIFOandLIFOMatch(t *testing.T) {
 	params := gopter.DefaultTestParameters()
 	params.MinSuccessfulTests = 1000
 	properties := gopter.NewProperties(params)
@@ -40,6 +40,11 @@ func TestPropMatchingRanges(t *testing.T) {
 			if len(lifo) != len(fifo) {
 				return "Length mismatch between lifo&fifo order"
 			}
+			if len(lifo) == 0 {
+				// nothing else to check
+				return ""
+			}
+
 			last := lifo[0]
 			for nth, _ := range lifo {
 				if lifo[nth] != fifo[len(fifo)-1-nth] {
@@ -52,7 +57,7 @@ func TestPropMatchingRanges(t *testing.T) {
 			}
 			return ""
 		},
-		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(0, 2000).WithLabel("ring size"),
 		gen.UIntRange(1, 100).WithLabel("overflow"),
 	))
 	properties.TestingRun(t)
@@ -84,12 +89,12 @@ func TestPropReserve(t *testing.T) {
 				return "unexpected error"
 			}
 
+			if overflows && reservedAny {
+				return fmt.Sprintf("would overflow, but reserved %d elements:\n%#v %#v",
+					first.Length()+second.Length(), first, second)
+			}
 			if !overflows && first.Length()+second.Length() != reserve {
 				return fmt.Sprintf("did not reserve %d elements:\n%#v %#v",
-					reserve, first, second)
-			}
-			if overflows && first.Length()+second.Length() != cap-startSize {
-				return fmt.Sprintf("overflowing, did not reserve %d elements:\n%#v %#v",
 					reserve, first, second)
 			}
 			if reservedAny && startIdx != first.Start {
@@ -114,7 +119,7 @@ func TestPropReserve(t *testing.T) {
 			}
 			return ""
 		},
-		gen.UIntRange(1, 2000).SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UIntRange(0, 2000).WithLabel("ring size"),
 		gen.UIntRange(0, 100).WithLabel("elements to fill in"),
 		gen.UIntRange(0, 100).WithLabel("elements to read"),
 		gen.UIntRange(0, 100).WithLabel("elements to reserve"),

--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -19,7 +19,7 @@ func TestPropMatchingRanges(t *testing.T) {
 			ring := o.NewRing(cap)
 			insert := cap + overage
 			for i := uint(0); i < insert; i++ {
-				o.ForcePush(ring)
+				ring.ForcePush()
 			}
 			if ring.Size() != cap {
 				return "Size does not match cap"
@@ -67,7 +67,7 @@ func TestPropReserve(t *testing.T) {
 			ring := o.NewRing(cap)
 			var startIdx uint
 			for i := uint(0); i < fill; i++ {
-				startIdx = ring.Mask(o.ForcePush(ring) + 1)
+				startIdx = ring.Mask(ring.ForcePush() + 1)
 			}
 			for i := uint(0); i < read; i++ {
 				ring.Shift()

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -191,7 +191,7 @@ func TestReserve(t *testing.T) {
 				ring.Shift()
 			}
 
-			first, second, err := o.Reserve(ring, test.add)
+			first, second, err := ring.PushN(test.add)
 			t.Log("Reserve:", first, second, err)
 			assert.Equal(t, test.first, first, "first")
 			assert.Equal(t, test.second, second, "second")

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -129,7 +129,7 @@ func TestConsume(t *testing.T) {
 			for i = 0; i < test.cycles; i++ {
 				test.ra.ForcePush()
 			}
-			first, second := o.Consume(test.ra)
+			first, second := test.ra.Consume()
 			t.Logf("%#v", test.ra)
 			assert.Equal(t, test.first, first, "first")
 			assert.Equal(t, test.second, second, "second")

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -27,7 +27,7 @@ func TestLIFO(t *testing.T) {
 			results := make([]uint, 0, len(test.expected))
 			var i uint
 			for i = 0; i < test.cycles; i++ {
-				o.ForcePush(test.ra)
+				test.ra.ForcePush()
 			}
 			s := o.ScanLIFO(test.ra)
 			for s.Next() {
@@ -58,7 +58,7 @@ func TestFIFO(t *testing.T) {
 			results := make([]uint, 0, len(test.expected))
 			var i uint
 			for i = 0; i < test.cycles; i++ {
-				o.ForcePush(test.ra)
+				test.ra.ForcePush()
 			}
 			s := o.ScanFIFO(test.ra)
 			for s.Next() {
@@ -92,7 +92,7 @@ func TestInspect(t *testing.T) {
 			t.Parallel()
 			var i uint
 			for i = 0; i < test.cycles; i++ {
-				o.ForcePush(test.ra)
+				test.ra.ForcePush()
 			}
 			before := test.ra.Size()
 			first, second := o.Inspect(test.ra)
@@ -127,7 +127,7 @@ func TestConsume(t *testing.T) {
 			t.Parallel()
 			var i uint
 			for i = 0; i < test.cycles; i++ {
-				o.ForcePush(test.ra)
+				test.ra.ForcePush()
 			}
 			first, second := o.Consume(test.ra)
 			t.Logf("%#v", test.ra)
@@ -185,7 +185,7 @@ func TestReserve(t *testing.T) {
 			t.Parallel()
 			ring := o.NewRing(test.cap)
 			for i := 0; i < test.fill; i++ {
-				o.ForcePush(ring)
+				ring.ForcePush()
 			}
 			for i := 0; i < test.read; i++ {
 				ring.Shift()

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -138,7 +138,7 @@ func TestConsume(t *testing.T) {
 	}
 }
 
-func TestReserve(t *testing.T) {
+func TestPushN(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
 		name          string
@@ -153,14 +153,14 @@ func TestReserve(t *testing.T) {
 			name:  "basic5/13",
 			cap:   5,
 			add:   13,
-			first: o.Range{0, 5}, second: o.Range{0, 0},
+			first: o.Range{0, 0}, second: o.Range{0, 0},
 			err: o.ErrFull,
 		},
 		{
 			name:  "mask4/13",
 			cap:   4,
 			add:   13,
-			first: o.Range{0, 4}, second: o.Range{0, 0},
+			first: o.Range{0, 0}, second: o.Range{0, 0},
 			err: o.ErrFull,
 		},
 		{
@@ -175,7 +175,7 @@ func TestReserve(t *testing.T) {
 			fill:  4,
 			read:  2,
 			add:   13,
-			first: o.Range{4, 5}, second: o.Range{0, 2},
+			first: o.Range{4, 4}, second: o.Range{0, 0},
 			err: o.ErrFull,
 		},
 	}
@@ -192,7 +192,6 @@ func TestReserve(t *testing.T) {
 			}
 
 			first, second, err := ring.PushN(test.add)
-			t.Log("Reserve:", first, second, err)
 			assert.Equal(t, test.first, first, "first")
 			assert.Equal(t, test.second, second, "second")
 			assert.Equal(t, test.err, err)

--- a/ranges_test.go
+++ b/ranges_test.go
@@ -95,7 +95,7 @@ func TestInspect(t *testing.T) {
 				test.ra.ForcePush()
 			}
 			before := test.ra.Size()
-			first, second := o.Inspect(test.ra)
+			first, second := test.ra.Inspect()
 			t.Logf("%#v", test.ra)
 			assert.Equal(t, test.first, first, "first")
 			assert.Equal(t, test.second, second, "second")

--- a/ring.go
+++ b/ring.go
@@ -21,7 +21,11 @@ const ErrEmpty emptyErr = iota
 const ErrFull fullErr = iota
 
 // Ring provides accounting functions for ring buffers.
-type Ring interface {
+type Ring struct {
+	ringBackend
+}
+
+type ringBackend interface {
 	// Push lets a writer account for a new element in the ring,
 	// and returns that element's index.
 	//
@@ -83,9 +87,9 @@ func ForcePush(r Ring) uint {
 // general modulo division for its integer math.
 func NewRing(cap uint) Ring {
 	if bits.OnesCount(cap) == 1 {
-		return &maskRing{cap: cap}
+		return Ring{&maskRing{cap: cap}}
 	}
-	return &basicRing{cap: cap}
+	return Ring{&basicRing{cap: cap}}
 }
 
 // A type, usually a collection, that has length. This is inspired by

--- a/ring.go
+++ b/ring.go
@@ -64,10 +64,11 @@ type ringBackend interface {
 	// points of the ring back to 0.
 	reset()
 
-	// add accounts for n new elements in the ring. If fewer
-	// elements could be accounted for, only accounts for the ones
-	// that could fit and returns ErrFull.
-	add(n uint) (uint, error)
+	// pushN accounts for n new elements in the ring and returns
+	// the indexes of the first and last element. If not all
+	// elements can be inserted, does not push them and returns
+	// only ErrNotFound.
+	pushN(n uint) (start uint, end uint, err error)
 }
 
 // ForcePush forces a new element onto the ring, discarding the oldest

--- a/ring.go
+++ b/ring.go
@@ -71,6 +71,13 @@ type ringBackend interface {
 	pushN(n uint) (start uint, end uint, err error)
 }
 
+// Capacity returns the number of continuous indexes that can be
+// represented on the ring. IOW, it returns the highest possible
+// index+1.
+func (r Ring) Capacity() uint {
+	return r.capacity()
+}
+
 // ForcePush forces a new element onto the ring, discarding the oldest
 // element if the ring is full. It returns the index of the inserted
 // element.

--- a/ring.go
+++ b/ring.go
@@ -28,8 +28,6 @@ type Ring struct {
 // Defines the functions implementations of the accountancy algorithms
 // need to provide.
 type ringBackend interface {
-	shift() (uint, error)
-
 	full() bool
 
 	empty() bool
@@ -55,6 +53,11 @@ type ringBackend interface {
 	// elements can be inserted, does not push them and returns
 	// only ErrNotFound.
 	pushN(n uint) (start uint, end uint, err error)
+
+	// shiftN "reads" n continuous indexes from the ring and
+	// returns the first and last (masked) index. If n is larger
+	// than the ring's Size, returns zeroes and ErrEmpty.
+	shiftN(n uint) (start uint, end uint, err error)
 }
 
 // Capacity returns the number of continuous indexes that can be
@@ -141,7 +144,8 @@ func (r Ring) Push() (uint, error) {
 //
 // Returns ErrEmpty if the ring has no elements to read.
 func (r Ring) Shift() (uint, error) {
-	return r.shift()
+	start, _, err := r.shiftN(1)
+	return start, err
 }
 
 // Size returns the number of elements in the ring buffer.

--- a/ring.go
+++ b/ring.go
@@ -73,7 +73,7 @@ type ringBackend interface {
 // ForcePush forces a new element onto the ring, discarding the oldest
 // element if the ring is full. It returns the index of the inserted
 // element.
-func ForcePush(r Ring) uint {
+func (r Ring) ForcePush() uint {
 	if r.Full() {
 		_, _ = r.Shift()
 	}

--- a/ring_properties_test.go
+++ b/ring_properties_test.go
@@ -28,7 +28,39 @@ func TestPropShiftPushes(t *testing.T) {
 		},
 		gen.UInt().WithLabel("ring size"),
 		gen.UIntRange(1, 257*90).WithLabel("number of entries made"),
-	),
-	)
+	))
+	properties.TestingRun(t)
+}
+
+func TestPropBounds(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 1000
+	properties := gopter.NewProperties(params)
+
+	properties.Property("Read own writes", prop.ForAll(
+		func(ringSize, entries uint) string {
+			ring := o.NewRing(ringSize)
+
+			_, _, err := ring.PushN(entries)
+			if entries > ringSize && err == nil {
+				return "should have errored"
+			}
+
+			if entries == ringSize && !ring.Full() {
+				return "should be full"
+			}
+
+			if entries < ringSize && ring.Full() {
+				return "should not be full"
+			}
+
+			if entries == 0 && !ring.Empty() {
+				return "should be empty"
+			}
+			return ""
+		},
+		gen.UInt().WithLabel("ring size"),
+		gen.UIntRange(0, 257*90).WithLabel("number of entries made"),
+	))
 	properties.TestingRun(t)
 }

--- a/ring_properties_test.go
+++ b/ring_properties_test.go
@@ -26,7 +26,7 @@ func TestPropShiftPushes(t *testing.T) {
 			}
 			return true
 		},
-		gen.UInt().SuchThat(func(x uint) bool { return x > 0 }).WithLabel("ring size"),
+		gen.UInt().WithLabel("ring size"),
 		gen.UIntRange(1, 257*90).WithLabel("number of entries made"),
 	),
 	)

--- a/ring_test.go
+++ b/ring_test.go
@@ -11,7 +11,7 @@ import (
 func TestForcePush(t *testing.T) {
 	r := NewRing(1)
 	r.Push()
-	assert.Equal(t, ForcePush(r), uint(0))
+	assert.Equal(t, r.ForcePush(), uint(0))
 }
 
 func TestPushAndShift(t *testing.T) {

--- a/ring_test.go
+++ b/ring_test.go
@@ -11,7 +11,7 @@ import (
 func TestForcePush(t *testing.T) {
 	r := NewRing(1)
 	r.Push()
-	assert.Equal(t, r.ForcePush(), uint(0))
+	assert.Equal(t, uint(0), r.ForcePush())
 }
 
 func TestPushAndShift(t *testing.T) {

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -46,14 +46,14 @@ func (b *Bounded) Write(p []byte) (n int, err error) {
 
 	n = len(p)
 	reserve := uint(len(p))
-	remaining := uint(len(b.buf)) - b.r.Size()
+	remaining := b.r.Capacity() - b.r.Size()
 	if remaining < uint(len(p)) {
 		if !b.overwrite {
 			return 0, o.ErrFull
 		}
 		// consume the bytes that we're over and reset input
 		// to fit:
-		p = p[len(p)-len(b.buf) : len(p)]
+		p = p[reserve-b.r.Capacity() : len(p)]
 		for i := uint(0); i <= b.r.Size(); i++ {
 			b.r.Shift()
 		}

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -72,18 +72,15 @@ func (b *Bounded) Read(p []byte) (n int, err error) {
 		return 0, nil
 	}
 
-	var i uint
-	for {
-		if n >= len(p) {
-			return
-		}
-		i, err = b.r.Shift()
-		if err == o.ErrEmpty {
-			return n, nil
-		}
-		p[n] = b.buf[i]
-		n++
+	n = int(b.r.Size())
+	if n > len(p) {
+		n = len(p)
 	}
+	var first, second o.Range
+	first, second, err = b.r.ShiftN(uint(n))
+	copy(p[0:first.Length()], b.buf[first.Start:first.End])
+	copy(p[first.Length():], b.buf[second.Start:second.End])
+	return
 }
 
 func (b *Bounded) reset() {

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -59,10 +59,7 @@ func (b *Bounded) Write(p []byte) (n int, err error) {
 		}
 		reserve = uint(len(p))
 	}
-	first, second, err := b.r.PushN(reserve)
-	if err != nil {
-		return 0, err
-	}
+	first, second, _ := b.r.PushN(reserve)
 	copy(b.buf[first.Start:first.End], p[0:first.Length()])
 	copy(b.buf[second.Start:second.End], p[first.Length():len(p)])
 	return

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -3,7 +3,6 @@
 package ringio
 
 import (
-	"io"
 	"sync"
 
 	"github.com/antifuchs/o"
@@ -70,7 +69,7 @@ func (b *Bounded) Read(p []byte) (n int, err error) {
 	defer b.Unlock()
 
 	if b.r.Empty() {
-		return 0, io.EOF
+		return 0, nil
 	}
 
 	var i uint

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -105,7 +105,7 @@ func (b *Bounded) Bytes() []byte {
 	b.Lock()
 	defer b.Unlock()
 
-	first, second := o.Consume(b.r)
+	first, second := b.r.Consume()
 	val := make([]byte, first.Length()+second.Length())
 	copy(val, b.buf[first.Start:first.End])
 	copy(val[first.End:], b.buf[second.Start:second.End])

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -19,13 +19,13 @@ func TestReadBoundedWrites(t *testing.T) {
 
 	n, err = b.Write([]byte("this will hit the capacity of the buffer"))
 	assert.Error(t, err)
-	assert.Equal(t, io.ErrShortWrite, err)
-	assert.Equal(t, 7, n)
+	assert.Equal(t, o.ErrFull, err)
+	assert.Equal(t, 0, n)
 
 	buf := make([]byte, 9)
 	n, err = b.Read(buf)
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("hithis wi"), buf)
+	assert.Equal(t, []byte("hi"), buf[0:n])
 }
 
 func TestReadOverwrites(t *testing.T) {

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -133,3 +133,11 @@ func TestString(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 	assert.Equal(t, 0, n)
 }
+
+func TestZero(t *testing.T) {
+	t.Parallel()
+	b := New(0, false)
+	n, err := b.Write([]byte("welp"))
+	assert.Equal(t, o.ErrFull, err)
+	assert.Equal(t, 0, n)
+}

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -1,7 +1,6 @@
 package ringio
 
 import (
-	"io"
 	"testing"
 
 	"github.com/antifuchs/o"
@@ -70,15 +69,15 @@ func TestParallel(t *testing.T) {
 		if err == o.ErrEmpty {
 			continue
 		}
-		if err == io.EOF {
-			break
-		}
 		require.NoError(t, err)
 		switch n {
 		case 3:
 			assert.Equal(t, []byte("abc"), didRead[0:3])
 		case 6:
 			assert.Equal(t, []byte("abcabc"), didRead)
+		case 0:
+			// nothing available, try again
+			i--
 		default:
 			t.Fatalf("Read %d bytes, expected 3 or 6", n)
 		}
@@ -102,7 +101,7 @@ func TestReset(t *testing.T) {
 	b.Reset()
 
 	n, err = b.Read(read)
-	assert.Equal(t, io.EOF, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
 }
 
@@ -116,7 +115,7 @@ func TestBytes(t *testing.T) {
 	assert.Equal(t, []byte("test"), b.Bytes())
 	read := make([]byte, 4)
 	n, err = b.Read(read)
-	assert.Equal(t, io.EOF, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
 }
 
@@ -130,7 +129,7 @@ func TestString(t *testing.T) {
 	assert.Equal(t, "test", b.String())
 	read := make([]byte, 4)
 	n, err = b.Read(read)
-	assert.Equal(t, io.EOF, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, n)
 }
 

--- a/zero.go
+++ b/zero.go
@@ -1,0 +1,46 @@
+package o
+
+// Implements the ring algorithms for rings of size 0. These are
+// special because we really would like to avoid division by zero.
+type zeroRing struct{}
+
+func (z zeroRing) shift() (uint, error) {
+	return 0, ErrFull
+}
+
+func (z zeroRing) full() bool {
+	return true
+}
+
+func (z zeroRing) empty() bool {
+	return false
+}
+
+func (z zeroRing) size() uint {
+	return 0
+}
+
+func (z zeroRing) mask(uint) uint {
+	return 0
+}
+
+func (z zeroRing) start() uint {
+	return 0
+}
+
+func (z zeroRing) end() uint {
+	return 0
+}
+
+func (z zeroRing) capacity() uint {
+	return 0
+}
+
+func (z zeroRing) reset() {
+}
+
+func (z zeroRing) pushN(n uint) (start uint, end uint, err error) {
+	return 0, 0, ErrFull
+}
+
+var _ ringBackend = zeroRing{}

--- a/zero.go
+++ b/zero.go
@@ -5,7 +5,7 @@ package o
 type zeroRing struct{}
 
 func (z zeroRing) shift() (uint, error) {
-	return 0, ErrFull
+	return 0, ErrEmpty
 }
 
 func (z zeroRing) full() bool {
@@ -36,8 +36,7 @@ func (z zeroRing) capacity() uint {
 	return 0
 }
 
-func (z zeroRing) reset() {
-}
+func (z zeroRing) reset() {}
 
 func (z zeroRing) pushN(n uint) (start uint, end uint, err error) {
 	return 0, 0, ErrFull

--- a/zero.go
+++ b/zero.go
@@ -4,8 +4,8 @@ package o
 // special because we really would like to avoid division by zero.
 type zeroRing struct{}
 
-func (z zeroRing) shift() (uint, error) {
-	return 0, ErrEmpty
+func (z zeroRing) shiftN(uint) (uint, uint, error) {
+	return 0, 0, ErrEmpty
 }
 
 func (z zeroRing) full() bool {

--- a/zero_test.go
+++ b/zero_test.go
@@ -1,0 +1,58 @@
+package o_test
+
+import (
+	"testing"
+
+	"github.com/antifuchs/o"
+	"github.com/stretchr/testify/assert"
+)
+
+func new() o.Ring {
+	return o.NewRing(0)
+}
+
+func TestZeroMeaningless(t *testing.T) {
+	r := new()
+	for i := 0; i < 2; i++ {
+		assert.False(t, r.Empty())
+		assert.True(t, r.Full())
+		assert.Equal(t, uint(0), r.Size())
+		assert.Equal(t, uint(0), r.Capacity())
+		r.Consume()
+	}
+}
+
+func TestZeroPush(t *testing.T) {
+	r := new()
+	var i uint
+
+	new, err := r.Push()
+	assert.Equal(t, o.ErrFull, err)
+	assert.Equal(t, i, new)
+}
+
+func TestZeroShift(t *testing.T) {
+	r := new()
+	_, err := r.Shift()
+	assert.Error(t, err)
+
+	var i uint
+	new, err := r.Push()
+	assert.Equal(t, o.ErrFull, err)
+	assert.Equal(t, uint(0), new)
+
+	i, err = r.Shift()
+	assert.Equal(t, o.ErrEmpty, err)
+	assert.Equal(t, uint(0), i)
+}
+
+func BenchmarkZeroRing(b *testing.B) {
+	r := new()
+	var i uint
+	for ; i < 1<<uint(b.N); i++ {
+		r.Push()
+	}
+	for i = 0; i < 1<<uint(b.N); i++ {
+		r.Shift()
+	}
+}


### PR DESCRIPTION
This PR aims at making the Ring interface a bit better & more regular:

* Move all the things one does on `o.Ring` to methods on a concrete struct.
* Make `Reserve` (now `PushN`) strict: Don't reserve more elements than are available.
* Make `ShiftN` for bulk "read"s like the one in the `ringio` Reader implementation

Also, tighten the coverage goals by making 100% project coverage required & adding codecov/project a required check for bors.