### PR TITLE
Enable more linters

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,20 +2,31 @@ version: 2.1
 orbs:
   codecov: codecov/codecov@1.0.2
 jobs:
-  gofmt:
+  lints:
     docker:
       - image: circleci/golang:1.9
     working_directory: /go/src/github.com/antifuchs/o
     steps:
       - checkout
       - run:
+          name: deps
+          command: |
+            go get -v -t -d ./...
+            go get -v -u golang.org/x/lint/golint
+            go get -v -u github.com/kisielk/errcheck
+      - run:
           name: gofmt
           command: |
             gofmt -w .
-      - run:
-          name: Check for differences
-          command: |
             git add . && git diff --cached && git diff-index --cached --exit-code HEAD
+      - run:
+          name: errcheck
+          command: |
+            errcheck -ignoretests ./...
+      - run:
+          name: golint
+          command: |
+            golint -set_exit_status ./...
 
   tests:
     docker:
@@ -93,11 +104,11 @@ workflows:
   version: 2
   continuous_integration:
     jobs:
-      - gofmt
       - tests
       - benchmarks
+      - lints
       - ci_success:
           requires:
-            - gofmt
             - tests
             - benchmarks
+            - lints

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,7 @@ orbs:
 jobs:
   lints:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/antifuchs/o
     steps:
       - checkout
@@ -21,7 +21,7 @@ jobs:
 
   tests:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/antifuchs/o
     steps:
       - checkout
@@ -57,7 +57,7 @@ jobs:
 
   benchmarks:
     docker:
-      - image: circleci/golang:1.9
+      - image: circleci/golang:1.12
     working_directory: /go/src/github.com/antifuchs/o
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,21 +12,12 @@ jobs:
           name: deps
           command: |
             go get -v -t -d ./...
-            go get -v -u golang.org/x/lint/golint
-            go get -v -u github.com/kisielk/errcheck
+            # golangci-lint:
+            env GO111MODULE=on go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.15.0
       - run:
-          name: gofmt
+          name: golangci-lint
           command: |
-            gofmt -w .
-            git add . && git diff --cached && git diff-index --cached --exit-code HEAD
-      - run:
-          name: errcheck
-          command: |
-            errcheck -ignoretests ./...
-      - run:
-          name: golint
-          command: |
-            golint -set_exit_status ./...
+            golangci-lint run -E goimports
 
   tests:
     docker:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,20 @@
+run:
+  deadline: "20s"
+  issues-exit-code: 1
+
+linters-settings:
+  errcheck:
+    check-blank: false
+
+linters:
+  enable:
+    - golint
+    - gochecknoglobals
+
+issues:
+  exclude-use-default: false
+  exclude-rules:
+    # Exclude errcheck from running on tests files.
+    - path: _test\.go
+      linters:
+        - errcheck

--- a/ranges.go
+++ b/ranges.go
@@ -139,10 +139,10 @@ func (s *Scanner) Next() bool {
 	}
 	if s.fifo {
 		s.cur = rg.End - 1
-		rg.End -= 1
+		rg.End--
 	} else {
 		s.cur = rg.Start
-		rg.Start += 1
+		rg.Start++
 	}
 	return true
 }

--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -46,7 +46,7 @@ func TestPropFIFOandLIFOMatch(t *testing.T) {
 			}
 
 			last := lifo[0]
-			for nth, _ := range lifo {
+			for nth := range lifo {
 				if lifo[nth] != fifo[len(fifo)-1-nth] {
 					return fmt.Sprintf("fifo / lifo mismatch:\n%#v\n%#v", lifo, fifo)
 				}

--- a/ring.go
+++ b/ring.go
@@ -99,10 +99,10 @@ func (r Ring) Mask(i uint) uint {
 	return r.mask(i)
 }
 
-// Returns a new Ring data structure with the given capacity. If cap
-// is a power of 2, returns a data structure that is optimized for
-// modulo-2 accesses. Otherwise, the returned data structure uses
-// general modulo division for its integer math.
+// NewRing returns a new Ring data structure with the given
+// capacity. If cap is a power of 2, returns a data structure that is
+// optimized for modulo-2 accesses. Otherwise, the returned data
+// structure uses general modulo division for its integer math.
 func NewRing(cap uint) Ring {
 	if cap == 0 {
 		return Ring{zeroRing{}}
@@ -113,8 +113,9 @@ func NewRing(cap uint) Ring {
 	return Ring{&basicRing{cap: cap}}
 }
 
-// A type, usually a collection, that has length. This is inspired by
-// (but kept intentionally smaller than) sort.Interface.
+// Slice represents a type, usually a collection, that has
+// length. This is inspired by (but kept intentionally smaller than)
+// sort.Interface.
 type Slice interface {
 	// Len returns the length of a slice.
 	Len() int

--- a/ringio/io.go
+++ b/ringio/io.go
@@ -1,4 +1,4 @@
-// package ringio implements a ring-buffer that is an io.Reader and an
+// Package ringio implements a ring-buffer that is an io.Reader and an
 // io.Writer with fixed-size semantics.
 package ringio
 
@@ -52,15 +52,15 @@ func (b *Bounded) Write(p []byte) (n int, err error) {
 		}
 		// consume the bytes that we're over and reset input
 		// to fit:
-		p = p[reserve-b.r.Capacity() : len(p)]
+		p = p[reserve-b.r.Capacity():]
 		for i := uint(0); i <= b.r.Size(); i++ {
-			b.r.Shift()
+			_, _ = b.r.Shift()
 		}
 		reserve = uint(len(p))
 	}
 	first, second, _ := b.r.PushN(reserve)
 	copy(b.buf[first.Start:first.End], p[0:first.Length()])
-	copy(b.buf[second.Start:second.End], p[first.Length():len(p)])
+	copy(b.buf[second.Start:second.End], p[first.Length():])
 	return
 }
 

--- a/ringio/io_test.go
+++ b/ringio/io_test.go
@@ -43,6 +43,7 @@ func TestReadOverwrites(t *testing.T) {
 	n, err = b.Read(buf)
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("he buffer"), buf)
+	assert.Equal(t, 9, n)
 }
 
 func TestParallel(t *testing.T) {
@@ -56,7 +57,7 @@ func TestParallel(t *testing.T) {
 			case <-quit:
 				return
 			default:
-				b.Write(toWrite)
+				_, _ = b.Write(toWrite)
 			}
 		}
 	}

--- a/ringio/properties_test.go
+++ b/ringio/properties_test.go
@@ -86,9 +86,9 @@ func TestPropReadWritesBounded(t *testing.T) {
 				n, err := b.Write(input)
 
 				if tooLong {
-					if n != 0 {
+					if n != 0 || err == nil {
 						return gopter.NewPropResult(false,
-							fmt.Sprintf("should not have written, but: %d", n))
+							fmt.Sprintf("should not have written, but: %d and %v", n, err))
 					}
 				}
 


### PR DESCRIPTION
This PR switches us to `golangci-lint` and runs most of them in CI.