### PR TITLE
Add a property test for ShiftN

### DIFF
--- a/ranges_properties_test.go
+++ b/ranges_properties_test.go
@@ -63,11 +63,11 @@ func TestPropFIFOandLIFOMatch(t *testing.T) {
 	properties.TestingRun(t)
 }
 
-func TestPropReserve(t *testing.T) {
+func TestPropPushN(t *testing.T) {
 	params := gopter.DefaultTestParameters()
 	params.MinSuccessfulTests = 10000
 	properties := gopter.NewProperties(params)
-	properties.Property("Ranges in scanners match", prop.ForAll(
+	properties.Property("Pushing N elements", prop.ForAll(
 		func(cap, fill, read, reserve uint) string {
 			ring := o.NewRing(cap)
 			var startIdx uint
@@ -123,6 +123,78 @@ func TestPropReserve(t *testing.T) {
 		gen.UIntRange(0, 100).WithLabel("elements to fill in"),
 		gen.UIntRange(0, 100).WithLabel("elements to read"),
 		gen.UIntRange(0, 100).WithLabel("elements to reserve"),
+	))
+	properties.TestingRun(t)
+}
+
+func TestPropShiftN(t *testing.T) {
+	params := gopter.DefaultTestParameters()
+	params.MinSuccessfulTests = 10000
+	properties := gopter.NewProperties(params)
+	properties.Property("Shifting N elements", prop.ForAll(
+		func(cap, fill, skip, read uint) string {
+			ring := o.NewRing(cap)
+
+			for i := uint(0); i < fill; i++ {
+				ring.ForcePush()
+			}
+			var startIdx uint
+			if fill > cap && cap > 0 {
+				startIdx = ring.Mask(fill - cap)
+			}
+			for i := uint(0); i < skip; i++ {
+				idx, err := ring.Shift()
+				if err == nil {
+					startIdx = ring.Mask(idx + 1)
+				}
+			}
+			startSize := ring.Size()
+
+			first, second, err := ring.ShiftN(read)
+			overflows := read > cap || read > startSize
+			readAny := !first.Empty() || !second.Empty()
+
+			if overflows && err == nil {
+				return "expected error"
+			}
+			if !overflows && err != nil {
+				return "unexpected error"
+			}
+
+			if overflows && readAny {
+				return fmt.Sprintf("would overflow, but read %d elements:\n%#v %#v",
+					first.Length()+second.Length(), first, second)
+			}
+			if !overflows && first.Length()+second.Length() != read {
+				return fmt.Sprintf("did not read %d elements:\n%#v %#v",
+					read, first, second)
+			}
+			if readAny && startIdx != first.Start {
+				return fmt.Sprintf("expected reservation to start at %d, but %#v",
+					startIdx, first)
+			}
+			if !second.Empty() && first.End != cap {
+				return fmt.Sprintf("bad end bound on first range: %d expected, but %#v",
+					cap, first)
+			}
+			if !second.Empty() && second.Start != 0 {
+				return fmt.Sprintf("bad start bound on second range: 0 expected, but %#v",
+					second)
+			}
+			if !second.Empty() && !overflows && second.End != read-first.Length() {
+				return fmt.Sprintf("bad end bound on second range: %d expected, but %#v %#v",
+					read-first.Length(), first, second)
+			}
+			if !second.Empty() && overflows && second.End != cap-startSize-first.Length() {
+				return fmt.Sprintf("bad end bound on overflowing second range: %d expected, but %#v %#v",
+					cap-startSize-first.Length(), first, second)
+			}
+			return ""
+		},
+		gen.UIntRange(0, 2000).WithLabel("ring size"),
+		gen.UIntRange(0, 100).WithLabel("elements to fill in"),
+		gen.UIntRange(0, 100).WithLabel("elements to skip before reading"),
+		gen.UIntRange(0, 100).WithLabel("elements to read"),
 	))
 	properties.TestingRun(t)
 }


### PR DESCRIPTION
This PR adds a new property test for `ShiftN`, similar to the one for `PushN`. Its input is compatible with the corresponding `TestShiftN` subtests, so failing proptests' parameters can be plugged in over there.