### PR TITLE
Add some warnings about unsafe combinations of functions to docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,11 @@
 
 ## Added
 
-* This CHANGELOG.md file and pull request templates by [antifuchs].
+* This CHANGELOG.md file by [antifuchs].
+* A pull request template. Thanks to [wireguy] for the debugging help
+  in [#13](https://github.com/antifuchs/o/issues/13).
+* API documentation around some unsafe API interactions. Thanks,
+  [antifuchs]!
 
 # [v1.0.0] - 2019-03-19
 
@@ -27,6 +31,7 @@
 <!-- github short links to contributors' profiles: -->
 [antifuchs]: https://github.com/antifuchs
 [jsnell]: https://github.com/jsnell
+[wireguy]: https://github.com/wireguy
 
 <!-- release version number short links: -->
 [v1.0.0]: https://github.com/antifuchs/o/releases/tag/v1.0.0

--- a/ranges.go
+++ b/ranges.go
@@ -102,8 +102,14 @@ func (r Ring) ShiftN(count uint) (first, second Range, err error) {
 }
 
 // Scanner implements iterating over the elements in a Ring without
-// removing them. A scanner can go in either LIFO (oldest element
-// first) or FIFO (newest element first) direction.
+// removing them. It represents a snapshot of the Ring at the time it
+// was created. A scanner can go in either LIFO (oldest element first)
+// or FIFO (newest element first) direction.
+//
+// A Scanner does not update its Ring's range validity when .Next is
+// called. Adding or reading elements from the Ring while a Scanner is
+// active can mean invalidated indexes will be returned from the
+// Scanner.
 type Scanner struct {
 	cur    uint
 	ranges []Range

--- a/ring.go
+++ b/ring.go
@@ -75,6 +75,12 @@ func (r Ring) Empty() bool {
 // ForcePush forces a new element onto the ring, discarding the oldest
 // element if the ring is full. It returns the index of the inserted
 // element.
+//
+// Using ForcePush to insert into the Ring means the Ring will lose
+// data that has not been consumed yet. This is fine under some
+// circumstances, but can have disastrous consequences for code that
+// expects to read consistent data. It is generally safer to use .Push
+// and handle ErrFull explicitly.
 func (r Ring) ForcePush() uint {
 	if r.full() {
 		_, _ = r.Shift()


### PR DESCRIPTION
# What does this change do?

This adds a few paragraphs of warnings to the api documentation, around:

* `ForcePush` and its overwrite-with-no-questions-asked behavior
* A `Scanner`'s indexes interacting with changes to the Ring.

# Checklist for code changes

- [ ] Check project test coverage remains at 100%
- [ ] Added an entry to [CHANGELOG.md](../../blob/master/CHANGELOG.md)